### PR TITLE
Support a single "service" folder packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack-prisma",
-  "version": "1.0.3",
+  "version": "1.0.4-alpha.0",
   "repository": "https://github.com/danieluhm2004/serverless-webpack-prisma.git",
   "author": "danieluhm2004 <iam@dan.al>",
   "description": "When using serverless webpack, you can save up to 50% of package capacity by deleting unnecessary Prisma engine.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack-prisma",
-  "version": "1.0.4-alpha.0",
+  "version": "1.0.4",
   "repository": "https://github.com/danieluhm2004/serverless-webpack-prisma.git",
   "author": "danieluhm2004 <iam@dan.al>",
   "description": "When using serverless webpack, you can save up to 50% of package capacity by deleting unnecessary Prisma engine.",

--- a/src/index.js
+++ b/src/index.js
@@ -56,8 +56,26 @@ class ServerlessWebpackPrisma {
     }
   }
 
+  // Ref: https://github.com/serverless-heaven/serverless-webpack/blob/4785eb5e5520c0ce909b8270e5338ef49fab678e/lib/utils.js#L115)
   getFunctions() {
-    return ['service'];
+    const functions = this.serverless.service.getAllFunctions();
+
+    return functions.filter((funcName) => {
+      const func = this.serverless.service.getFunction(funcName);
+
+      // if `uri` is provided or simple remote image path, it means the
+      // image isn't built by Serverless so we shouldn't take care of it
+      if (
+        (func.image && func.image.uri) ||
+        (func.image && typeof func.image == 'string')
+      ) {
+        return false;
+      }
+
+      return this.isNodeRuntime(
+        func.runtime || this.serverless.service.provider.runtime || 'nodejs'
+      );
+    });
   }
 
   isNodeRuntime(runtime) {

--- a/src/index.js
+++ b/src/index.js
@@ -56,26 +56,8 @@ class ServerlessWebpackPrisma {
     }
   }
 
-  // Ref: https://github.com/serverless-heaven/serverless-webpack/blob/4785eb5e5520c0ce909b8270e5338ef49fab678e/lib/utils.js#L115)
   getFunctions() {
-    const functions = this.serverless.service.getAllFunctions();
-
-    return functions.filter((funcName) => {
-      const func = this.serverless.service.getFunction(funcName);
-
-      // if `uri` is provided or simple remote image path, it means the
-      // image isn't built by Serverless so we shouldn't take care of it
-      if (
-        (func.image && func.image.uri) ||
-        (func.image && typeof func.image == 'string')
-      ) {
-        return false;
-      }
-
-      return this.isNodeRuntime(
-        func.runtime || this.serverless.service.provider.runtime || 'nodejs'
-      );
-    });
+    return ['service'];
   }
 
   isNodeRuntime(runtime) {

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ class ServerlessWebpackPrisma {
       unusedEngines.forEach((engine) => {
         this.serverless.cli.log(`- ${engine}`);
         const enginePath = path.join(cwd, engine);
-        fse.rmSync(enginePath, { force: true });
+        fse.removeSync(enginePath, { force: true });
       });
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,9 @@ class ServerlessWebpackPrisma {
   onBeforeWebpackPackage() {
     const { servicePath } = this.serverless.config;
     const prismaDir = path.join(servicePath, 'prisma');
-    for (const functionName of this.getFunctions()) {
+    const packageIndividually = this.serverless.configurationInput.package && this.serverless.configurationInput.package.individually;
+    const functionNames = packageIndividually ? this.getFunctions() : ['service'];
+    for (const functionName of functionNames) {
       const cwd = path.join(servicePath, '.webpack', functionName);
       const targetPrismaDir = path.join(cwd, 'prisma');
       this.serverless.cli.log(`Copy prisma schema for ${functionName}...`);


### PR DESCRIPTION
A single "service" folder packaging occurs when the serverless project doesn't specify `package.individually` in its serverless.yml file. 

With package.individually = false, the webpack places all project files into a single ".webpack/service" folder instead of ".webpack/{functionName}" individually before packaging.

This pull request contains an implementation that determines package.individually value and decide whether to use function names or a single `['service']` as folder names when deleting unused engine files.

Bonus: also update the function call from `rmSync` to `removeSync`