### PR TITLE
feat: added flags to control deps and dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Serverless Webpack Prisma
 
-When using serverless webpack, you can save up to 50% of package capacity by deleting unnecessary Prisma engine.
+When using serverless webpack, you can save up to 50% of package capacity by deleting unnecessary Prisma engines.
 
 ## How to use?
 
@@ -28,16 +28,16 @@ custom:
         - prisma generate
 ```
 
-This plugin also have some aditional configs:
+This plugin also has some additional configs:
 
 ```yaml
 custom:
   prisma:
-    installDeps: false #Passing false will not install prisma dependenci during the build process. Default true
-    prismaPath: ../../ #Passing this param, plugin will change the directory to find the dir prisma containig the prisma/prismna.schema
+    installDeps: false # Passing false will not install Prisma dependency during the build process. Default: true
+    prismaPath: ../../ # Passing this param, plugin will change the directory to find the dir prisma containing the prisma/prisma.schema
 ```
 
-Congratulations. Setup is complete. In the future, packaging will automatically delete unnecessary resources.
+Congratulations. The setup is complete. In the future, packaging will automatically delete unnecessary resources.
 
 ```
 Serverless: Generate prisma client for app...

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ custom:
         - prisma generate
 ```
 
+This plugin also have some aditional configs:
+
+```yaml
+custom:
+  prisma:
+    installDeps: false #Passing false will not install prisma dependenci during the build process. Default true
+    prismaPath: ../../ #Passing this param, plugin will change the directory to find the dir prisma containig the prisma/prismna.schema
+```
+
 Congratulations. Setup is complete. In the future, packaging will automatically delete unnecessary resources.
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack-prisma",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "repository": "https://github.com/danieluhm2004/serverless-webpack-prisma.git",
   "author": "danieluhm2004 <iam@dan.al>",
   "description": "When using serverless webpack, you can save up to 50% of package capacity by deleting unnecessary Prisma engine.",

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -22,7 +22,7 @@ describe('Check serverless-webpack-prisma plugin', () => {
         provider: {},
         getAllFunctions: () => [],
         getFunction: () => ({}),
-        custom: { webpack: {} },
+        custom: { webpack: {}, prisma: { installDeps: true, prismaPath: '' } },
       },
     });
   });
@@ -35,6 +35,22 @@ describe('Check serverless-webpack-prisma plugin', () => {
 
   test('getPackageManager() is "npm"', () =>
     expect(plugin.getPackageManager()).toEqual('npm'));
+
+  test('getSchemaPath() is "root"', () =>
+    expect(plugin.getSchemaPath()).toEqual(''));
+
+  test('getSchemaPath() is "../../prisma"', () => {
+    plugin.serverless.service.custom.prisma = { prismaPath: '../../prisma' };
+    expect(plugin.getSchemaPath()).toEqual('../../prisma');
+  });
+
+  test('getDepsParam() is default true', () =>
+      expect(plugin.getDepsParam()).toEqual(true));
+
+  test('getDepsParam() is false"', () => {
+    plugin.serverless.service.custom.prisma = { installDeps: true };
+    expect(plugin.getDepsParam()).toEqual(true);
+  });
 
   test('getPackageManager() is "yarn"', () => {
     plugin.serverless.service.custom.webpack = { packager: 'yarn' };


### PR DESCRIPTION
Found some problems when using the package with `lerna`.

In this scenario, the schema file is not present in the same dir of the `serverless.yml` file being compiled. This will cause a error in the copy process.

Also found a problem during the `prisma` dependence install, when using lerna with yarn workspaces is not allowed to install or remove dependencies directly with yarn. In this cases prisma should be previously installed on package.json being compiled.

This way we have 2 new params inside the serverless.yml file:

![image](https://user-images.githubusercontent.com/54671744/154422800-847fc9c4-3fed-47f7-b81a-91d5bbd3ef28.png)

this closes https://github.com/danieluhm2004/serverless-webpack-prisma/issues/5