### PR TITLE
Also remove engines in the prisma/engines directory

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,8 @@ class ServerlessWebpackPrisma {
 
     'node_modules/@prisma/engines/introspection-engine*',
     '!node_modules/@prisma/engines/introspection-engine-rhel*',
+
+    'node_modules/prisma/engines/**',
   ];
 
   constructor(serverless, options) {


### PR DESCRIPTION
We were finding that extra, seemingly duplicated prisma engines were being output to this directory, so added this new glob pattern to match and remove them. This has not been widely tested to confirm suitability for all workflows or environments, though I've raised a pull request in case others find this useful.