### PR TITLE
Use custom.prisma.version parameter when using Yarn as package manager

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ class ServerlessWebpackPrisma {
     const command =
       this.getPackageManager() === 'npm'
         ? `npm install ${params}${packageName}${version}`
-        : `yarn add ${params}${packageName}`;
+        : `yarn add ${params}${packageName}${version}`;
     childProcess.execSync(command, { cwd });
   }
 


### PR DESCRIPTION
Fixes https://github.com/danieluhm2004/serverless-webpack-prisma/issues/36 as Yarn was not using the given version number when installing Prisma.

This is particularly important lately as Prisma has released some breaking changes to the `schema` folder and their generate process. Anyone (including myself) using Yarn to deploy now is blocked using this package unless they upgrade to the latest Prisma versions.